### PR TITLE
Add Intent generation functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ templates:
   - oh_no!
 ```
 
+`intents.md`
+
+```
+<!-- 2019-04-18 15:03:32.000000 | 6f9354ab-c1e3-4342-a1b1-192a514a0388 -->
+## intent:something
+- {thing}
+- I want to do {thing}
+- Can I do {thing}?
+- Let me do {thing}?
+```
+
 ### Guide
 
 - clone this repo and create `/.env` with the following content:

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -11,5 +11,5 @@ it('runs', async () => {
 it('generates non-empty /output', async () => {
   await promisify(exec)('npm start');
   const contents = await fs.promises.readdir(join(process.cwd(), '/output'));
-  expect(contents).toHaveLength(2);
+  expect(contents).toHaveLength(3);
 });

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import * as utils from '@botmock-api/utils';
 import { stringify as toYAML } from 'yaml';
 import chalk from 'chalk';
 import fs from 'fs';
+import { genIntents } from './lib/nlu';
 import { toMd } from './lib/nlp';
 import SDKWrapper from './lib/SDKWrapper';
 import { OUTPUT_PATH } from './constants';
@@ -88,6 +89,13 @@ ${toYAML({
   templates
 })}`
   );
+
+  // Write intent file (see https://rasa.com/docs/nlu/dataformat/)
+  await fs.promises.writeFile(
+    `${OUTPUT_PATH}/intents.md`,
+    genIntents(intents)
+  );
+
   // Write story file (see https://rasa.com/docs/core/stories/#format)
   await fs.promises.writeFile(
     `${STORIES_PATH}/story.md`,

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ try {
 // Output the following directory hierarchy:
 // output/
 //   |── domain.yml
+//   |── nlu.md
 //   └── project_name/
 //       └── story.md
 try {
@@ -92,7 +93,7 @@ ${toYAML({
 
   // Write intent file (see https://rasa.com/docs/nlu/dataformat/)
   await fs.promises.writeFile(
-    `${OUTPUT_PATH}/intents.md`,
+    `${OUTPUT_PATH}/nlu.md`,
     genIntents(intents)
   );
 

--- a/lib/nlu.js
+++ b/lib/nlu.js
@@ -1,0 +1,25 @@
+export function genIntents(intents) {
+  const genExample = ({ text, variables }) => {
+    if (variables) {
+      let output = text;
+      variables.forEach(({ name }) => {
+        // side-effect: replaces Botmock var with Rasa entity
+        output = output.replace(name, `{${name.slice(1, name.length - 1)}}`);
+      });
+      return `- ${output}`;
+    } else {
+      return `- ${text}`;
+    }
+  };
+
+  // for each intent, create comment with id an timestamp
+  const genIntent = ({ id, name, utterances: examples, updated_at: { date : timestamp } }) => {
+    return `
+<!-- ${timestamp} | ${id} -->
+## intent:${name}
+${examples.map(example => genExample(example)).join('\n')}
+`;
+  };
+  
+  return `${intents.map(intent => genIntent(intent)).join('\n')}`;
+}

--- a/lib/nlu.js
+++ b/lib/nlu.js
@@ -3,8 +3,13 @@ export function genIntents(intents) {
     if (variables) {
       let output = text;
       variables.forEach(({ name }) => {
-        // side-effect: replaces Botmock var with Rasa entity
-        output = output.replace(name, `{${name.slice(1, name.length - 1)}}`);
+        // side-effect: replaces Botmock variable with Rasa entity
+        const search = new RegExp(name, 'gi');
+        const formattedName = name
+          .slice(1, name.length - 1)
+          .replace(/ /gi, '_')
+          .toLowerCase();
+        output = output.replace(search, `[${formattedName}](${formattedName})`);
       });
       return `- ${output}`;
     } else {
@@ -13,13 +18,18 @@ export function genIntents(intents) {
   };
 
   // for each intent, create comment with id an timestamp
-  const genIntent = ({ id, name, utterances: examples, updated_at: { date : timestamp } }) => {
+  const genIntent = ({
+    id,
+    name,
+    utterances: examples,
+    updated_at: { date: timestamp }
+  }) => {
     return `
 <!-- ${timestamp} | ${id} -->
-## intent:${name}
+## intent:${name.replace(/ /gi, '_').toLowerCase()}
 ${examples.map(example => genExample(example)).join('\n')}
 `;
   };
-  
+
   return `${intents.map(intent => genIntent(intent)).join('\n')}`;
 }


### PR DESCRIPTION
Currently, the exporter only generates the names of intents in domain.yml. We should have functionality to allow for intent generation from the intents endpoint of the Botmock API.

This PR will add intent generation functionality based on the Rasa format [here](https://rasa.com/docs/nlu/dataformat/).

- [x] fix tests to include intent file in output
- [x] create function to generate intents
    - created in `lib/nlu.js`
- [x] generate intents in `index.js`
- [x] run tests to assure functionality
- [x] update README.md