### PR TITLE
partially fix newline bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ try {
           }
           return {
             ...acc_,
-            [type || m.message_type]: payload || m.payload[m.message_type]
+            [type || m.message_type]: payload || `${m.payload[m.message_type] ? m.payload[m.message_type].replace(/\n/g, '\\n') : m.payload[m.message_type]}`
           };
         }, {})
       };


### PR DESCRIPTION
## Bug description

When an utterance has `\n` in its text like below:

```jsonc
{
    "message_id": "0110217a-eff3-43b0-ae12-364ed9bd32c6",
    // ...
    "payload": {
      "nodeName": "Bot Says",
      "text": "{someContent}\n\n{someMoreContent}",
      // ...
    }
}
```

 the exporter will provide the following output:

```yaml
bot_says-{messageId}:
    text: >-
      {someContent}

      {someMoreContent}
```

Since it should be agnostic of any escape characters, the desired output should be:

```yaml
bot_says-{messageId}:
    text: "{someContent}\n\n{someMoreContent}"
```

## Changes

script will now output the text with escape characters included, and produce below output:

```yaml
bot_says-{messageId}:
    text: {someContent}\n\nT{someMoreContent}
```

### Current issues with change

does *not* wrap string in quotes as desired