### PR TITLE
update readme to show current entity extraction instead of slot replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ templates:
 ```
 <!-- 2019-04-18 15:03:32.000000 | 6f9354ab-c1e3-4342-a1b1-192a514a0388 -->
 ## intent:something
-- {thing}
-- I want to do {thing}
-- Can I do {thing}?
-- Let me do {thing}?
+- [thing](thing)
+- I want to do [thing](thing)
+- Can I do [thing](thing)?
+- Let me do [thing](thing)?
 ```
 
 ### Guide


### PR DESCRIPTION
Just updating the readme to reflect the current output from `nlu.md`, forgot to make that change before.  Just as before, it is working under the assumption that the entity extracted has the same name as the Rasa slot.  May be coming back to this area specifically, in order to help generate some varied intent examples based on the entity synonyms provided in Botmock's entity definition, as described [here](https://rasa.com/docs/nlu/dataformat/#markdown-format).